### PR TITLE
Add a make target for unused dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,5 +32,5 @@ test: build-deterministic-wasi-ctx-test-programs
 	cargo test --package deterministic-wasi-ctx
 
 unused-dependencies:
-	cargo install cargo-udeps --locked
+	cargo install cargo-udeps --locked --version ~0.1
 	cargo +nightly udeps


### PR DESCRIPTION
Normally I wouldn't include a `cargo install` command in a make target but it runs quickly if it's already installed and the dependency isn't necessary for most operations involving the crate. We can also change it later easily enough.