### PR TITLE
Add docs for a release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,8 @@ Run `make test` to run integration tests.
 ## Structure
 
 The `deterministic-wasi-ctx-test-programs` crate is used to build a collection of Wasm files invoking WASI functions that the integration tests in the `deterministic-wasi-ctx` crate use to verify the output from those Wasm files is deterministic.
+
+## Releasing
+
+1. Create and merge a PR incrementing the crates' versions in accordance with [SemVer](https://semver.org/) based on changes from the previous release
+1. Create a new release in [Github](https://github.com/Shopify/deterministic-wasi-ctx/releases/new) with a name like `v0.1.0` where the version matches the crates' versions


### PR DESCRIPTION
I was debating if it would be worth following the versioning advice in _Rust for Rustaceans_ on page 83 to page 84 on _Unreleased Versions_ but it's quite a bit different from how folks normally manage versions and is a bit complicated to explain so I'm opting against it for now. I was also debating if we want to look into following the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format to make versioning decisions easier but we can do that later if we choose to. I'll also open a follow up these changes to add publishing the crate to crates.io as another step after publishing the first version of the crate.