### PR TITLE
Fix version in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "deterministic-wasi-ctx"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
Not sure why the `Cargo.lock` is in this state 🤔 
