### PR TITLE
Lock deps to reduce chance of lockfiles being out of sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ clean:
 	cargo clean
 
 build-deterministic-wasi-ctx:
-	cargo build --package deterministic-wasi-ctx
+	cargo build --locked --package deterministic-wasi-ctx
 
 build-deterministic-wasi-ctx-test-programs:
-	cargo build --package deterministic-wasi-ctx-test-programs --target wasm32-wasi
+	cargo build --locked --package deterministic-wasi-ctx-test-programs --target wasm32-wasi
 
 crate-checks:
 	cargo install --locked --version ~0.12 cargo-deny && cargo deny check
@@ -26,18 +26,18 @@ deterministic-wasi-ctx-test-programs:
 fmt: fmt-deterministic-wasi-ctx fmt-deterministic-wasi-ctx-test-programs
 
 fmt-deterministic-wasi-ctx:
-	cargo fmt --package deterministic-wasi-ctx -- --check \
+	cargo fmt --locked --package deterministic-wasi-ctx -- --check \
 		&& cargo clippy --package deterministic-wasi-ctx -- -D warnings
 
 fmt-deterministic-wasi-ctx-test-programs:
-	cargo fmt --package deterministic-wasi-ctx-test-programs -- --check \
+	cargo fmt --locked --package deterministic-wasi-ctx-test-programs -- --check \
 		&& cargo clippy --package deterministic-wasi-ctx-test-programs --target wasm32-wasi -- -D warnings
 
 publish:
 	cargo publish --package deterministic-wasi-ctx
 
 test: build-deterministic-wasi-ctx-test-programs
-	cargo test --package deterministic-wasi-ctx
+	cargo test --locked --package deterministic-wasi-ctx
 
 unused-dependencies:
 	cargo install cargo-udeps --locked --version ~0.1

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@ deterministic-wasi-ctx-test-programs:
 fmt: fmt-deterministic-wasi-ctx fmt-deterministic-wasi-ctx-test-programs
 
 fmt-deterministic-wasi-ctx:
-	cargo fmt --locked --package deterministic-wasi-ctx -- --check \
+	cargo fmt --package deterministic-wasi-ctx -- --check \
 		&& cargo clippy --package deterministic-wasi-ctx -- -D warnings
 
 fmt-deterministic-wasi-ctx-test-programs:
-	cargo fmt --locked --package deterministic-wasi-ctx-test-programs -- --check \
+	cargo fmt --package deterministic-wasi-ctx-test-programs -- --check \
 		&& cargo clippy --package deterministic-wasi-ctx-test-programs --target wasm32-wasi -- -D warnings
 
 publish:


### PR DESCRIPTION
Should prevent having to do something like https://github.com/Shopify/deterministic-wasi-ctx/pull/18 in the future