### PR TITLE
bumping version to 0.1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "deterministic-wasi-ctx"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/deterministic-wasi-ctx/Cargo.toml
+++ b/crates/deterministic-wasi-ctx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deterministic-wasi-ctx"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 description = "A wasi-common WasiCtx implementation that is fully deterministic"


### PR DESCRIPTION
Let's release with wasmtime 8:  https://github.com/Shopify/deterministic-wasi-ctx/pull/48