### PR TITLE
It is better to use the repository field

### DIFF
--- a/crates/deterministic-wasi-ctx/Cargo.toml
+++ b/crates/deterministic-wasi-ctx/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.20"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 description = "A wasi-common WasiCtx implementation that is fully deterministic"
-homepage = "https://github.com/Shopify/deterministic-wasi-ctx"
+repository = "https://github.com/Shopify/deterministic-wasi-ctx"
 keywords = ["wasi"]
 categories = ["wasm"]
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.