### PR TITLE
Bump crate version to 0.1.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "deterministic-wasi-ctx"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/deterministic-wasi-ctx/Cargo.toml
+++ b/crates/deterministic-wasi-ctx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deterministic-wasi-ctx"
-version = "0.1.27"
+version = "0.1.28"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 description = "A wasi-common WasiCtx implementation that is fully deterministic"


### PR DESCRIPTION
Bump crate version to 0.1.28. The only change is a Wasmtime version bump to 28.

Changes: https://github.com/Shopify/deterministic-wasi-ctx/compare/v0.1.27...main