### PR TITLE
Refactor integration tests

### DIFF
--- a/crates/deterministic-wasi-ctx/tests/clocks.rs
+++ b/crates/deterministic-wasi-ctx/tests/clocks.rs
@@ -1,33 +1,43 @@
+use anyhow::Result;
+
 mod common;
 
 #[test]
-fn test_realtime_clock() {
-    let (store, instance) = common::create_instance("clocks.wasm");
-    let result = common::invoke_func::<(), u64>(store, instance, "realtime", ());
-    let expected_clock_output = 0;
-    assert_eq!(result, expected_clock_output);
+fn test_realtime_clock() -> Result<()> {
+    common::test_instance("clocks.wasm", |invoke_func| {
+        let result: i64 = invoke_func("realtime", ())?;
+        let expected_clock_output = 0;
+        assert_eq!(result, expected_clock_output);
+        Ok(())
+    })
 }
 
 #[test]
-fn test_realtime_clock_seq_calls() {
-    let (store, instance) = common::create_instance("clocks.wasm");
-    let result = common::invoke_func::<(), u64>(store, instance, "realtime_seq_calls", ());
-    let expected_clock_diff = 0;
-    assert_eq!(result, expected_clock_diff);
+fn test_realtime_clock_seq_calls() -> Result<()> {
+    common::test_instance("clocks.wasm", |invoke_func| {
+        let result: i64 = invoke_func("realtime_seq_calls", ())?;
+        let expected_clock_diff = 0;
+        assert_eq!(result, expected_clock_diff);
+        Ok(())
+    })
 }
 
 #[test]
-fn test_monotonic_clock() {
-    let (store, instance) = common::create_instance("clocks.wasm");
-    let result = common::invoke_func::<(), u64>(store, instance, "monotonic", ());
-    let expected_clock_output = 0;
-    assert_eq!(result, expected_clock_output);
+fn test_monotonic_clock() -> Result<()> {
+    common::test_instance("clocks.wasm", |invoke_func| {
+        let result: i64 = invoke_func("monotonic", ())?;
+        let expected_clock_output = 0;
+        assert_eq!(result, expected_clock_output);
+        Ok(())
+    })
 }
 
 #[test]
-fn test_monotonic_clock_seq_calls() {
-    let (store, instance) = common::create_instance("clocks.wasm");
-    let result = common::invoke_func::<(), u64>(store, instance, "monotonic_seq_calls", ());
-    let expected_clock_diff = 0;
-    assert_eq!(result, expected_clock_diff);
+fn test_monotonic_clock_seq_calls() -> Result<()> {
+    common::test_instance("clocks.wasm", |invoke_func| {
+        let result: i64 = invoke_func("monotonic_seq_calls", ())?;
+        let expected_clock_diff = 0;
+        assert_eq!(result, expected_clock_diff);
+        Ok(())
+    })
 }

--- a/crates/deterministic-wasi-ctx/tests/common/mod.rs
+++ b/crates/deterministic-wasi-ctx/tests/common/mod.rs
@@ -1,26 +1,34 @@
+use anyhow::Result;
 use std::path::Path;
 use wasi_common::WasiCtx;
 use wasmtime::*;
 
-pub fn create_instance(module_name: &str) -> (Store<WasiCtx>, Instance) {
+pub fn test_instance<Params, Results, F>(module_name: &str, testcase: F) -> Result<()>
+where
+    Params: WasmParams,
+    Results: WasmResults,
+    F: Fn(Box<dyn FnOnce(&str, Params) -> Result<Results>>) -> Result<()>,
+{
     let wasi = deterministic_wasi_ctx::build_wasi_ctx();
     let engine = Engine::default();
     let mut linker = Linker::new(&engine);
-    wasi_common::sync::add_to_linker(&mut linker, |s| s).unwrap();
+    wasi_common::sync::add_to_linker(&mut linker, |s| s)?;
     let module_path = Path::new("../../target/wasm32-wasip1/debug").join(module_name);
-    let module = Module::from_file(&engine, module_path).unwrap();
+    let module = Module::from_file(&engine, module_path)?;
     let mut store = Store::new(&engine, wasi);
-    linker.module(&mut store, "", &module).unwrap();
-    let instance = linker.instantiate(&mut store, &module).unwrap();
-    (store, instance)
+    linker.module(&mut store, "", &module)?;
+    let instance = linker.instantiate(&mut store, &module)?;
+    testcase(Box::new(move |func_name, params| {
+        invoke_func(store, instance, func_name, params)
+    }))
 }
 
-pub fn invoke_func<Params, Results>(
+fn invoke_func<Params, Results>(
     mut store: Store<WasiCtx>,
     instance: Instance,
     func_name: &str,
     params: Params,
-) -> Results
+) -> Result<Results>
 where
     Params: WasmParams,
     Results: WasmResults,
@@ -28,6 +36,6 @@ where
     let answer = instance
         .get_func(&mut store, func_name)
         .unwrap_or_else(|| panic!("`{}` was not an exported function", func_name));
-    let answer = answer.typed::<Params, Results>(&store).unwrap();
-    answer.call(&mut store, params).unwrap()
+    let answer = answer.typed::<Params, Results>(&store)?;
+    answer.call(&mut store, params)
 }

--- a/crates/deterministic-wasi-ctx/tests/random.rs
+++ b/crates/deterministic-wasi-ctx/tests/random.rs
@@ -1,17 +1,23 @@
+use anyhow::Result;
+
 mod common;
 
 #[test]
-fn test_random() {
-    let (store, instance) = common::create_instance("random.wasm");
-    let result = common::invoke_func::<(), i32>(store, instance, "random", ());
-    let expected_random_output = 155;
-    assert_eq!(result, expected_random_output);
+fn test_random() -> Result<()> {
+    common::test_instance("random.wasm", |invoke_func| {
+        let result: i32 = invoke_func("random", ())?;
+        let expected_random_output = 155;
+        assert_eq!(result, expected_random_output);
+        Ok(())
+    })
 }
 
 #[test]
-fn test_random_two_invocations() {
-    let (store, instance) = common::create_instance("random.wasm");
-    let result = common::invoke_func::<(), i32>(store, instance, "random_two_invocations", ());
-    let expected_random_output = 111;
-    assert_eq!(result, expected_random_output);
+fn test_random_two_invocations() -> Result<()> {
+    common::test_instance("random.wasm", |invoke_func| {
+        let result: i32 = invoke_func("random_two_invocations", ())?;
+        let expected_random_output = 111;
+        assert_eq!(result, expected_random_output);
+        Ok(())
+    })
 }

--- a/crates/deterministic-wasi-ctx/tests/scheduler.rs
+++ b/crates/deterministic-wasi-ctx/tests/scheduler.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use std::time::Instant;
 
 mod common;
@@ -6,19 +7,21 @@ mod common;
 extern crate more_asserts;
 
 #[test]
-fn test_sleep() {
-    let (store, instance) = common::create_instance("scheduler.wasm");
-    let start = Instant::now();
-    common::invoke_func::<(), ()>(store, instance, "sleep", ());
-    let duration = start.elapsed();
-    assert_lt!(duration.as_millis(), 100);
+fn test_sleep() -> Result<()> {
+    common::test_instance::<_, (), _>("scheduler.wasm", |invoke_func| {
+        let start = Instant::now();
+        invoke_func("sleep", ())?;
+        let duration = start.elapsed();
+        assert_lt!(duration.as_millis(), 100);
+        Ok(())
+    })
 }
 
 #[test]
-fn test_yield() {
-    let (store, instance) = common::create_instance("scheduler.wasm");
-
-    // it's difficult to test that yielding isn't yielding in practice since sched_yield is very fast
-    // it's still worth testing that it doesn't panic
-    common::invoke_func::<(), ()>(store, instance, "yield", ());
+fn test_yield() -> Result<()> {
+    common::test_instance("scheduler.wasm", |invoke_func| {
+        // it's difficult to test that yielding isn't yielding in practice since sched_yield is very fast
+        // it's still worth testing that it doesn't panic
+        invoke_func("yield", ())
+    })
 }


### PR DESCRIPTION
Refactor integration test suite to prepare for using the same test cases for testing a `wasmtime-wasi` implementation as well as a `wasi-common` implementation of a deterministic WASI context. The two big changes are:
1. Use `anyhow::Result` instead of `unwrap`. This is more of a stylistic than functional change.
2. Don't let the test cases see the `Store` or `Instance` variables and use a closure to handle passing them around to function invocation. The reason for this change is using a different WASI context changes the type of the `Store` and I couldn't figure a good way to have the same test case code handle those different types of stores other than writing a procedural macro. Using a function that takes a test case closure as an argument seems a bit easier to understand and maintain to me compared to a procedural macro.