### PR TITLE
v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "deterministic-wasi-ctx"
-version = "0.1.34"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ let instance = linker.instantiate(&mut store, &module).unwrap();
 
 ## Contributing
 
-`deterministic-wasi-ctx` is a beta project and will be under major development. We welcome feedback, bug reports and bug fixes. We're also happy to discuss feature development but please discuss the features in an issue before contributing.
+We welcome feedback, bug reports and bug fixes. We're also happy to discuss feature development but please discuss the features in an issue before contributing.
 
 ## Build dependencies
 

--- a/crates/deterministic-wasi-ctx/Cargo.toml
+++ b/crates/deterministic-wasi-ctx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deterministic-wasi-ctx"
-version = "0.1.34"
+version = "1.0.0"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 description = "A wasmtime-wasi WasiCtx implementation that is fully deterministic"


### PR DESCRIPTION
Given the breaking changes from removing the `wasi-common` APIs, at least a minor version bump is warranted. I think we should remove the beta status and just go to v1.0.0.