### PR TITLE
v4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "deterministic-wasi-ctx"
-version = "3.0.6"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/deterministic-wasi-ctx/Cargo.toml
+++ b/crates/deterministic-wasi-ctx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deterministic-wasi-ctx"
-version = "3.0.6"
+version = "4.0.0"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 description = "A wasmtime-wasi WasiCtx implementation that is fully deterministic"


### PR DESCRIPTION
I'm incrementing the major version for this release because the return type for `replace_scheduling_functions` and `replace_scheduling_functions_for_wasi_preview_0` has changed to return `wasmtime::Error` instead of `anyhow::Error`.